### PR TITLE
Make createRuntime() public

### DIFF
--- a/library/src/main/java/com/hippo/quickjs/android/QuickJS.java
+++ b/library/src/main/java/com/hippo/quickjs/android/QuickJS.java
@@ -73,7 +73,7 @@ public class QuickJS implements TypeAdapter.Depot {
   /**
    * Creates a JSRuntime with resources in this QuickJS.
    */
-  JSRuntime createJSRuntime() {
+  public JSRuntime createJSRuntime() {
     long runtime = QuickJS.createRuntime();
     if (runtime == 0) {
       throw new IllegalStateException("Cannot create JSRuntime instance");


### PR DESCRIPTION
I might be missing something here, but when I tried to use quickjs-android as a library I couldn't because `createRuntime()` wasn't public. Once I changed that it worked great.